### PR TITLE
updateMetadataById

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- adding `updateMetadataById` to fix metadata update (without effecting other keys in metadata)
 
 ## 1.6.0 - 2023-05-02
 

--- a/src/services/artifacts.service.ts
+++ b/src/services/artifacts.service.ts
@@ -1,9 +1,22 @@
-import { CreateAxiosDefaults } from 'axios';
+import { AxiosPromise, AxiosRequestConfig, CreateAxiosDefaults } from 'axios';
 import { Artifact } from '../common';
 import { BaseService } from './core';
 
 export class ArtifactsService extends BaseService<Artifact> {
   constructor(protected readonly path: string, protected readonly options?: CreateAxiosDefaults) {
     super(path, options);
+  }
+
+  public async updateMetadataById(
+    id: string,
+    entity: Artifact,
+    config?: AxiosRequestConfig,
+  ): AxiosPromise<Artifact> {
+    return this.patch<Artifact>(`${this.path}/${id}/metadata`, entity, {
+      headers: {
+        Authorization: `Bearer ${(config ?? this.options)?.headers?.common?.Authorization}`,
+      },
+      ...config,
+    });
   }
 }


### PR DESCRIPTION
`updateById` would remove all metadata keys and override the new metadata on it. Now the `updateMetadataById` only affects metadata and it will update it (not rewrite it)
